### PR TITLE
rate limiter implemented

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -25,3 +25,11 @@ func (r *RedisStore) Get(ctx context.Context, key string) ([]byte, error) {
 func (r *RedisStore) Del(ctx context.Context, key string) error {
 	return r.redisClient.Del(ctx, key).Err()
 }
+
+func (r *RedisStore) Incr(ctx context.Context, key string) (int64, error) {
+	return r.redisClient.Incr(ctx, key).Result()
+}
+
+func (r *RedisStore) Exists(ctx context.Context, key string) (int64, error) {
+	return r.redisClient.Exists(ctx, key).Result()
+}

--- a/store.go
+++ b/store.go
@@ -9,4 +9,6 @@ type CodeStore interface {
 	Set(ctx context.Context, key string, value any, ttl time.Duration) error
 	Get(ctx context.Context, key string) ([]byte, error)
 	Del(ctx context.Context, key string) error
+	Incr(ctx context.Context, key string) (int64, error)
+	Exists(ctx context.Context, key string) (int64, error)
 }


### PR DESCRIPTION
Greetings,
I have implemented a rate limiter in the ssh.go file. It will save clients in Redis by their IP. I added two functions to the redis.go file to be able to use Exists and Incr methods of Redis. If a client sends over 100 requests in one hour, it will be blocked for one hour. These times could be changed easily. Please let me know if there is any problem with the implemented code.
Sincerely yours, Shayan Shabani