### PR TITLE
Implement rate limiter for ssh handler;

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func main() {
 		DB:       GetRedisDBOrPanic(),
 	})
 	redisStore := NewRedisStore(redisClient)
+	rateLimiter := NewRateLimiter(redisStore)
 
 	chatCrawlerDetector := NewChatCrawlerDetector()
 	tunnelManager := NewTunnelManager()
@@ -67,7 +68,7 @@ func main() {
 	}()
 
 	privateKey := ssh.HostKeyFile(GetPublicKeyOrPanic())
-	sshServer := NewSSHServer(sugar, redisStore, tunnelManager, GetHostOrPanic())
+	sshServer := NewSSHServer(sugar, redisStore, rateLimiter, tunnelManager, GetHostOrPanic())
 	sugar.Infow("starting ssh server", "addr", fmt.Sprintf(":%s", GetSSHPortOrPanic()))
 	if err := sshServer.ListenAndServe(fmt.Sprintf(":%s", GetSSHPortOrPanic()), nil, privateKey); err != nil {
 		sugar.Errorw("failed to start ssh server", "err", err)

--- a/rate_limiter.go
+++ b/rate_limiter.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+const (
+	MaxAttempts    = 100
+	RateLimiterTTL = time.Hour
+)
+
+type RateLimiter struct {
+	store Store
+}
+
+func NewRateLimiter(store Store) *RateLimiter {
+	return &RateLimiter{
+		store: store,
+	}
+}
+
+func (r *RateLimiter) KeyValue(key string) string {
+	return fmt.Sprintf("rate_limiter:%s", key)
+}
+
+func (r *RateLimiter) IsRateLimited(ctx context.Context, key string) (bool, error) {
+	key = r.KeyValue(key)
+	currentValue, err := r.store.Get(ctx, key)
+	if err != nil && !errors.Is(err, ErrKeyNotFound) {
+		return false, err
+	}
+	if string(currentValue) == "" {
+		currentValue = []byte("0")
+	}
+	count, err := strconv.Atoi(string(currentValue))
+	if err != nil {
+		return false, err
+	}
+	if count >= MaxAttempts {
+		return true, nil
+	}
+	val, err := r.store.Incr(ctx, key)
+	if err != nil {
+		return false, err
+	}
+	if val == 1 {
+		err = r.store.Expire(ctx, key, RateLimiterTTL)
+		if err != nil {
+			return false, err
+		}
+	}
+	return false, nil
+}

--- a/redis.go
+++ b/redis.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"github.com/redis/go-redis/v9"
 	"time"
 )
@@ -18,14 +19,25 @@ func (r *RedisStore) Set(ctx context.Context, key string, value any, ttl time.Du
 	return r.redisClient.Set(ctx, key, value, ttl).Err()
 }
 
-func (r *RedisStore) Incr(ctx context.Context, key string) error {
-	return r.redisClient.Incr(ctx, key).Err()
+func (r *RedisStore) Incr(ctx context.Context, key string) (int64, error) {
+	return r.redisClient.Incr(ctx, key).Result()
 }
 
 func (r *RedisStore) Get(ctx context.Context, key string) ([]byte, error) {
-	return r.redisClient.Get(ctx, key).Bytes()
+	res, err := r.redisClient.Get(ctx, key).Bytes()
+	switch {
+	case errors.Is(err, redis.Nil):
+		return nil, ErrKeyNotFound
+	case err != nil:
+		return nil, err
+	}
+	return res, nil
 }
 
 func (r *RedisStore) Del(ctx context.Context, key string) error {
 	return r.redisClient.Del(ctx, key).Err()
+}
+
+func (r *RedisStore) Expire(ctx context.Context, key string, ttl time.Duration) error {
+	return r.redisClient.Expire(ctx, key, ttl).Err()
 }

--- a/store.go
+++ b/store.go
@@ -2,12 +2,18 @@ package main
 
 import (
 	"context"
+	"errors"
 	"time"
 )
 
-type CodeStore interface {
+var (
+	ErrKeyNotFound = errors.New("key not found")
+)
+
+type Store interface {
 	Set(ctx context.Context, key string, value any, ttl time.Duration) error
 	Get(ctx context.Context, key string) ([]byte, error)
 	Del(ctx context.Context, key string) error
-	Incr(ctx context.Context, key string) error
+	Incr(ctx context.Context, key string) (int64, error)
+	Expire(ctx context.Context, key string, ttl time.Duration) error
 }


### PR DESCRIPTION
implemented it directly on the handler. There was no need to do traditional middleware handling like in http handlers because there is only one single SSH handler

closes #2 